### PR TITLE
Bug fixes and Internet + API call reduction

### DIFF
--- a/Android/Pittsburgh_Realtime_Tracker/app/build.gradle
+++ b/Android/Pittsburgh_Realtime_Tracker/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "rectangledbmi.com.pittsburghrealtimetracker"
         minSdkVersion 16
         targetSdkVersion 21
-        versionCode 31
-        versionName "3.0"
+        versionCode 32
+        versionName "3.2"
     }
     buildTypes {
         release {

--- a/Android/Pittsburgh_Realtime_Tracker/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/NavigationDrawerFragment.java
+++ b/Android/Pittsburgh_Realtime_Tracker/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/NavigationDrawerFragment.java
@@ -2,6 +2,7 @@ package rectangledbmi.com.pittsburghrealtimetracker;
 
 
 import android.app.Activity;
+import android.os.Environment;
 import android.support.v7.app.ActionBar;
 import android.support.v4.app.Fragment;
 import android.content.SharedPreferences;
@@ -13,6 +14,7 @@ import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -25,6 +27,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -406,6 +409,19 @@ public class NavigationDrawerFragment extends Fragment {
         mDrawerListView.clearChoices();
         ((SelectTransit)getActivity()).clearAndAddToMap();
         amountSelected = 0;
+        File lineInfo = new File(getActivity().getFilesDir(), "/lineinfo");
+        Log.i("clear-files", lineInfo.getAbsolutePath());
+        if(lineInfo.exists()) {
+            File[] files = lineInfo.listFiles();
+            if(files != null) {
+                for(File file : files) {
+                    file.delete();
+                }
+            }
+        }
+        SharedPreferences sp = PreferenceManager
+                .getDefaultSharedPreferences(getActivity());
+        sp.edit().putLong("lines_last_updated", System.currentTimeMillis()).apply();
         Toast.makeText(getActivity(), "Cleared buses.", Toast.LENGTH_SHORT).show();
 
     }

--- a/Android/Pittsburgh_Realtime_Tracker/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/handlers/InputSave.java
+++ b/Android/Pittsburgh_Realtime_Tracker/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/handlers/InputSave.java
@@ -1,0 +1,66 @@
+package rectangledbmi.com.pittsburghrealtimetracker.handlers;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import rectangledbmi.com.pittsburghrealtimetracker.hidden.PortAuthorityAPI;
+
+/**
+ * Inspired by http://stackoverflow.com/questions/8986376/how-to-download-xml-file-from-server-and-save-it-in-sd-card
+ *
+ * Created by epicstar on 1/12/15.
+ */
+public class InputSave {
+    private Context context;
+
+    public InputSave(Context context) {
+        this.context = context;
+    }
+
+    public void saveFile(String selectedRoute) {
+        try {
+            File file = new File(context.getFilesDir(), "/lineinfo/" + selectedRoute + ".xml");
+            if(!file.exists()) {
+                URL url = PortAuthorityAPI.getPatterns(selectedRoute);
+                URLConnection conexion = url.openConnection();
+                conexion.connect();
+                int lengthOfFile = conexion.getContentLength();
+                InputStream is = url.openStream();
+
+                FileOutputStream fos = new FileOutputStream(file);
+                byte data[] = new byte[1024];
+                int count = 0;
+                long total = 0;
+                int progress = 0;
+                while ((count = is.read(data)) != -1) {
+                    total += count;
+                    int progress_temp = (int) total * 100 / lengthOfFile;
+                    if (progress_temp % 10 == 0 && progress != progress_temp) {
+                        progress = progress_temp;
+                    }
+                    fos.write(data, 0, count);
+                }
+                is.close();
+                fos.close();
+                Log.i("save_file", selectedRoute + " attempted file saved...");
+            }
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/Android/Pittsburgh_Realtime_Tracker/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/handlers/RequestTask.java
+++ b/Android/Pittsburgh_Realtime_Tracker/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/handlers/RequestTask.java
@@ -3,6 +3,7 @@ package rectangledbmi.com.pittsburghrealtimetracker.handlers;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -19,6 +20,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import rectangledbmi.com.pittsburghrealtimetracker.R;
 import rectangledbmi.com.pittsburghrealtimetracker.SelectTransit;
 import rectangledbmi.com.pittsburghrealtimetracker.hidden.PortAuthorityAPI;
 import rectangledbmi.com.pittsburghrealtimetracker.world.Bus;
@@ -95,7 +97,10 @@ public class RequestTask extends AsyncTask<Void, Void, List<Bus>> {
 
             Log.i("onPostExecute task_start", "Task starting after thread ran");
 
-            if (bl != null) {
+            if(bl == null || bl.isEmpty()) {
+                Toast.makeText(context, "Routes not found. Either there is no route information, no internet connection, or the API Call limit has been exceeded.", Toast.LENGTH_LONG).show();
+
+            } else {
 
                 ConcurrentMap<Integer, Marker> newBusMarkers = new ConcurrentHashMap<>(bl.size());
                 LatLng latlng;

--- a/Android/Pittsburgh_Realtime_Tracker/app/src/main/res/values/strings.xml
+++ b/Android/Pittsburgh_Realtime_Tracker/app/src/main/res/values/strings.xml
@@ -305,7 +305,8 @@
     <string name="vincent">Vincent Agresti (Project Manager)</string>
     <string name="remark_1">This application is open source:</string>
     <string name="source_code">https://github.com/rectangle-dbmi/Realtime-Port-Authority</string>
-    <string name="versionName">3.0</string>
+    <string name="versionName">3.2</string>
+    <string name="directory_in_sdcard">/Data/rectangledbmi.com.pittsburghrealtimetracker</string>
     <string name="zoom_level">15.0</string>
     <string name="disclaim">DISCLAMER: We are not responsible for which buses and routes are being tracked as we are only getting the information from Port Authority. If a certain route or bus is not on our app, this is most likely not our fault but of Port Authority. If the map is empty, please report this to our Play Store email or create an issue on our Github above immediately.</string>
     <string name="route_not_found">is not found. Either there is no route information, no internet connection, or the API Call limit has been exceeded.</string>


### PR DESCRIPTION
Big backend changes............

XMLs now save to context.getFileDirs(), "/lineinfo/<route>.xml". This will delete every week or every time we press "Clear Transit"

Clear Transit now will correctly clear polylines. Polylines now sync with the list view 100% (if it disappears, we can bring it back by reselecting the route).

Pushed to beta 3.2
