### PR TITLE
Replace some toasts with snackbars

### DIFF
--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/BusMapFragment.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/BusMapFragment.java
@@ -22,7 +22,6 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import com.github.pwittchen.reactivenetwork.library.ConnectivityStatus;
 import com.github.pwittchen.reactivenetwork.library.ReactiveNetwork;
@@ -567,7 +566,7 @@ public class BusMapFragment extends SelectionFragment implements GoogleApiClient
                     // theoretically, this should only resubscribe when internet is back
                     if (throwable instanceof IOException){
                         if (busListInteraction != null) {
-                            busListInteraction.showToast(getString(R.string.disconnected_internet), Toast.LENGTH_SHORT);
+                            busListInteraction.makeSnackbar(getString(R.string.disconnected_internet), Snackbar.LENGTH_SHORT, null, null);
                         }
                         return Observable
                                 .timer(2, TimeUnit.SECONDS)
@@ -597,7 +596,7 @@ public class BusMapFragment extends SelectionFragment implements GoogleApiClient
                                             busListInteraction != null) {
                                         String msg = getString(R.string.retrying_vehicles);
                                         Timber.d(msg);
-                                        busListInteraction.showToast(msg, Toast.LENGTH_SHORT);
+                                        busListInteraction.makeSnackbar(msg, Snackbar.LENGTH_SHORT, null, null);
                                         return false;
                                     }
                                     return true;
@@ -856,16 +855,15 @@ public class BusMapFragment extends SelectionFragment implements GoogleApiClient
             @Override
             public void onError(Throwable e) {
                 if (e instanceof SocketTimeoutException) {
-                    busListInteraction.showToast(getString(R.string.retrofit_http_error), Toast.LENGTH_SHORT);
+                    busListInteraction.makeSnackbar(getString(R.string.retrofit_http_error), Snackbar.LENGTH_SHORT, null, null);
                 } else if (e.getMessage() != null && e.getLocalizedMessage() != null && !showedErrors) {
                     showedErrors = true;
                     if (e instanceof HttpException) {
                         HttpException http = (HttpException) e;
-                        busListInteraction.showToast(http.code() + " " + http.message() + ": "
-                                + getString(R.string.retrofit_http_error), Toast.LENGTH_SHORT);
+                        busListInteraction.makeSnackbar(http.code() + " " + http.message() + ": " + getString(R.string.retrofit_http_error), Snackbar.LENGTH_SHORT, null, null);
                     } else {
                         Timber.e("Vehicle error not handled.");
-                        busListInteraction.showToast(getString(R.string.retrofit_conversion_error), Toast.LENGTH_SHORT);
+                        busListInteraction.makeSnackbar(getString(R.string.retrofit_conversion_error), Snackbar.LENGTH_SHORT, null, null);
                     }
                     Timber.e(e, "bus_vehicle_error");
                 }
@@ -959,9 +957,9 @@ public class BusMapFragment extends SelectionFragment implements GoogleApiClient
             @Override
             public void onNext(ErrorMessage errorMessage) {
                 if (errorMessage != null && errorMessage.getMessage() != null) {
-                    busListInteraction.showToast(errorMessage.getMessage() +
+                    busListInteraction.makeSnackbar(errorMessage.getMessage() +
                                     (errorMessage.getParameters() != null ? ": " + errorMessage.getParameters() : ""),
-                            Toast.LENGTH_SHORT);
+                            Snackbar.LENGTH_SHORT, null, null);
                 }
             }
         };

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/SelectionFragment.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/SelectionFragment.java
@@ -9,6 +9,8 @@ package rectangledbmi.com.pittsburghrealtimetracker;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.view.View;
 
@@ -44,21 +46,13 @@ public abstract class SelectionFragment extends Fragment implements NavigationDr
         PATAPI getPatApiClient();
 
         /**
-         * Shows a toast message
-         *
-         * @param message the message
-         * @param length  the length of the message
-         */
-        void showToast(String message, int length);
-
-        /**
          * @return the Rx Observable that the {@link NavigationDrawerFragment} emits list clicks on.
          */
         Observable<RouteSelection> getSelectionSubject();
 
         void showOkDialog(String message, DialogInterface.OnClickListener okListener);
 
-        void makeSnackbar(@NonNull String message, int length, @NonNull String action, @NonNull View.OnClickListener listener);
+        void makeSnackbar(@NonNull String string, @Snackbar.Duration int showLength, @Nullable String action, @Nullable View.OnClickListener listener);
 
         /**
          * Opens the permissions page

--- a/app/src/main/res/layout/activity_select_transit.xml
+++ b/app/src/main/res/layout/activity_select_transit.xml
@@ -21,14 +21,21 @@
         <!--</FrameLayout>-->
 
 
-    <!-- TODO: expect this to be programmatically called from now on-->
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/map"
-        android:name="rectangledbmi.com.pittsburghrealtimetracker.BusMapFragment"
-        tools:layout="@layout/fragment_bus_map" />
+        android:id="@+id/coordinatorLayout">
+
+        <!-- TODO: expect this to be programmatically called from now on-->
+        <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/map"
+            android:name="rectangledbmi.com.pittsburghrealtimetracker.BusMapFragment"
+            tools:layout="@layout/fragment_bus_map" />
+
+    </android.support.design.widget.CoordinatorLayout>
 
     <!-- android:layout_gravity="start" tells DrawerLayout to treat
          this as a sliding drawer on the left side for left-to-right


### PR DESCRIPTION
Most of the toasts with snackbars, as well as attaching existing ones to a CoordinatorLayout instead of a DrawerLayout (this was causing multiple messages to appear on top of each other). Toasts from the NavigationDrawerFragment have not been replaced as they are not visible when the drawer is open.