### PR TITLE
update reactive network dependency, make sure unsubscription doesn't happen in predictions and polylines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     //3rd party android libraries
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.2.1'
-    compile 'com.github.pwittchen:reactivenetwork:0.2.0'
+    compile 'com.github.pwittchen:reactivenetwork:0.6.0'
 
     compile 'com.squareup.retrofit2:retrofit:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/patterns/PatternViewModel.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/patterns/PatternViewModel.java
@@ -70,7 +70,9 @@ public class PatternViewModel {
                                             route.getRoute(),
                                             route.getRouteColor()));
 
-                }).share();
+                })
+                .retry()
+                .share();
     }
 
     /**

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/predictions/PredictionsViewModel.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/predictions/PredictionsViewModel.java
@@ -46,6 +46,8 @@ public class PredictionsViewModel {
                     }
                     Timber.w("Not getting predictions because of unknown prediction info");
                     return Observable.never();
-                }).delay(delay, TimeUnit.MILLISECONDS);
+                })
+                .retry()
+                .delay(delay, TimeUnit.MILLISECONDS);
     }
 }

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/ReactiveHelper.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/ReactiveHelper.java
@@ -46,10 +46,17 @@ public class ReactiveHelper {
                                 null
                         )
                         .skipWhile(isConnected -> !isConnected)
-                        .doOnNext(reconnectionMessage);
+                        .doOnNext(isConnected -> {
+                            if (isConnected) {
+                                reconnectionMessage.call(true);
+                            }
+                            else {
+                                Timber.i("Internet is still disconnected in retryWhen.");
+                            }
+                        });
             }
             // otherwise, just run normal onError
-            Timber.d(throwable, "Not retrying since something should be wrong on " +
+            Timber.i(throwable, "Not retrying since something should be wrong on " +
                     "Port Authority's end.");
             return Observable.error(throwable);
         });

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/ReactiveHelper.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/ReactiveHelper.java
@@ -1,0 +1,81 @@
+package rectangledbmi.com.pittsburghrealtimetracker.utils;
+
+import com.github.pwittchen.reactivenetwork.library.ReactiveNetwork;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+import rx.Observable;
+import rx.functions.Action1;
+import rx.functions.Func1;
+import timber.log.Timber;
+
+/**
+ * <p>Helper methods for shared reactive methods.</p>
+ * <p>Created by epicstar on 10/21/16.</p>
+ * @author Jeremy Jao
+ * @since 80
+ */
+
+public class ReactiveHelper {
+
+    /**
+     * <p>Use in a {@link Observable#compose(Observable.Transformer)} when listening to state to reconnect
+     *    from the internet using {@link Observable#retryWhen(Func1)}</p>
+     * @param disconnectionMessage lambda that should print out a disconnection message
+     * @param reconnectionMessage lambda that should print out a reconnection message
+     * @return a transformer for composing retrying internet
+     */
+    public static Observable.Transformer<Throwable, Boolean> retryIfInternet(
+            Action1<Throwable> disconnectionMessage,
+            Action1<Boolean> reconnectionMessage
+    ) {
+        return throwableObservable -> throwableObservable
+                .doOnNext(disconnectionMessage)
+                .flatMap(throwable -> {
+            // theoretically, this should only resubscribe when internet is back
+            if (isInternetDown(throwable)) {
+                return ReactiveNetwork
+                        .observeInternetConnectivity(
+                                new WalledInternetStrategy(),
+                                2000,
+                                2000,
+                                "http://clients3.google.com/generate_204",
+                                80,
+                                2000,
+                                null
+                        )
+                        .skipWhile(isConnected -> !isConnected)
+                        .doOnNext(reconnectionMessage);
+            }
+            // otherwise, just run normal onError
+            Timber.d(throwable, "Not retrying since something should be wrong on " +
+                    "Port Authority's end.");
+            return Observable.error(throwable);
+        });
+    }
+
+
+    /**
+     * Decides if internet is down on the mobile device.
+     * @param throwable the error
+     * @return true if internet on the mobile device
+     */
+    public static boolean isInternetDown(Throwable throwable) {
+        /*
+         Jeremy Jao: note an edge case where if on a tablet and android says wifi has some sort of spotty
+         internet, retrofit/okhttp will still try to send an HTTP request and will throw a Socket Timeout
+         Exception. This is bad because the app will say "Internet disconnected please try again later,
+         but in reality, most likely, it's still up
+         (this is our only we know the Port Authority servers are up or down since they don't give us error responses).
+         This means that users will have to restart the app for it to function again.
+
+         I believe that Retrofit should be instead detecting what the Android OS is saying about
+         wifi state and should return an IOException so I'm leaving this behavior for now... Perhaps
+         to be revisited at some point.
+        */
+        return (throwable instanceof IOException && (
+                !(throwable instanceof SocketTimeoutException))
+        );
+    }
+}

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/WalledInternetStrategy.java
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/WalledInternetStrategy.java
@@ -1,0 +1,64 @@
+package rectangledbmi.com.pittsburghrealtimetracker.utils;
+
+import com.github.pwittchen.reactivenetwork.library.Preconditions;
+import com.github.pwittchen.reactivenetwork.library.internet.observing.InternetObservingStrategy;
+import com.github.pwittchen.reactivenetwork.library.internet.socket.SocketErrorHandler;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import rx.Observable;
+import rx.schedulers.Schedulers;
+
+/**
+ * <p>Implemented another {@link InternetObservingStrategy} since
+ *    {@link com.github.pwittchen.reactivenetwork.library.internet.observing.strategy.DefaultInternetObservingStrategy}
+ *    does not account for walled garden internet.</p>
+ * <p>Created by epicstar on 10/23/16.</p>
+ * @author Jeremy Jao
+ * @since 80
+ */
+
+public class WalledInternetStrategy implements InternetObservingStrategy {
+    @Override
+    public Observable<Boolean> observeInternetConnectivity(
+            int initialIntervalInMs,
+            int intervalInMs,
+            String host,
+            int port,
+            int timeoutInMs,
+            SocketErrorHandler socketErrorHandler)
+    {
+        Preconditions.checkGreaterOrEqualToZero(initialIntervalInMs,
+                "initialIntervalInMs is not a positive number");
+        Preconditions.checkGreaterThanZero(intervalInMs, "intervalInMs is not a positive number");
+        Preconditions.checkNotNullOrEmpty(host, "host is null or empty");
+        Preconditions.checkGreaterThanZero(port, "port is not a positive number");
+        Preconditions.checkGreaterThanZero(timeoutInMs, "timeoutInMs is not a positive number");
+        // socketErrorHandler is null because it's not being used here.
+        return Observable.interval(initialIntervalInMs, intervalInMs, TimeUnit.MILLISECONDS, Schedulers.io())
+                .map(aLong -> {
+                    HttpURLConnection urlConnection = null;
+                    try {
+                        URL url = new URL(host); // "http://clients3.google.com/generate_204"
+                        urlConnection = (HttpURLConnection) url.openConnection();
+                        urlConnection.setInstanceFollowRedirects(false);
+                        urlConnection.setConnectTimeout(timeoutInMs);
+                        urlConnection.setReadTimeout(timeoutInMs);
+                        urlConnection.setUseCaches(false);
+                        urlConnection.getInputStream();
+                        // We got a valid response, but not from the real google
+                        return urlConnection.getResponseCode() == 204;
+                    } catch (IOException e) {
+                        return false;
+                    } finally {
+                        if (urlConnection != null) {
+                            urlConnection.disconnect();
+                        }
+                    }
+                })
+                .distinctUntilChanged();
+    }
+}


### PR DESCRIPTION
I updated the reactivenetwork dependency such that we handle the walled garden case correctly. I had to end up extending a certain Reactive Network class so that we can handle the walled garden case.

In addition to this, I added retries on the Pattern and Predictions ViewModel observable so that if there's an error upstream, the clicks do not get disabled. @mikeantonacci I know you wanted to make the app be unresponsive when there's no internet (which I still have my reservations about), so I'm making a pull request to communicate that this behavior will happen now (which will mimic its previous behavior), and so that when we end up wanting to actually implement your feature, it will be clear which lines of code you want to move out.