### PR TITLE
#311: move all shared versions between projects in the root build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,18 +2,22 @@ apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.github.ben-manes.versions'
 
+// version dependnecies should be added via ../build.gradle -> `region versions for dependencies`
+// I did this since we can have multiple projects and they should all share the same versions
+// only exception to this are the published versions of each code specific to the project
+
 android.buildTypes.each { type ->
     type.buildConfigField 'String', 'PAT_API_KEY', patApiKey // variable defined in `../build.gradle`
 }
 
 android {
 
-    compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    compileSdkVersion androidTargetSdkVersion
+    buildToolsVersion androidBuildVersion
     defaultConfig {
         applicationId "rectangledbmi.com.pittsburghrealtimetracker"
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidTargetSdkVersion
         versionCode 80
         versionName "8.0.0b3"
     }
@@ -32,8 +36,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility javaVersion
+        targetCompatibility javaVersion
     }
 
 }
@@ -50,39 +54,39 @@ dependencies {
     }
 
      //google play services maps
-    compile 'com.google.android.gms:play-services-maps:10.0.1'
+    compile "com.google.android.gms:play-services-maps:${googlePlayVersion}"
     //google play services location and places
-    compile 'com.google.android.gms:play-services-location:10.0.1'
-    compile 'com.google.android.gms:play-services-places:10.0.1'
+    compile "com.google.android.gms:play-services-location:${googlePlayVersion}"
+    compile "com.google.android.gms:play-services-places:${googlePlayVersion}"
 
-    compile 'com.android.support:support-v4:23.4.0'
-    compile 'com.android.support:design:23.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile "com.android.support:support-v4:${androidDependencyVersion}"
+    compile "com.android.support:design:${androidDependencyVersion}"
+    compile "com.android.support:appcompat-v7:${androidDependencyVersion}"
+    compile "com.android.support:recyclerview-v7:${androidDependencyVersion}"
 
-    compile 'com.android.support:mediarouter-v7:23.4.0'
+    compile "com.android.support:mediarouter-v7:${androidDependencyVersion}"
 
     //3rd party android libraries
-    compile 'io.reactivex:rxandroid:1.2.1'
-    compile 'io.reactivex:rxjava:1.2.1'
-    compile 'com.github.pwittchen:reactivenetwork:0.6.0'
+    compile "io.reactivex:rxandroid:${rxJavaVersion}"
+    compile "io.reactivex:rxjava:${rxJavaVersion}"
+    compile "com.github.pwittchen:reactivenetwork:${reactiveNetworkVersion}"
 
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
-    compile 'org.glassfish:javax.annotation:10.0-b28'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    compile "com.squareup.retrofit2:converter-gson:${retrofitVersion}"
+    compile "com.squareup.retrofit2:adapter-rxjava:${retrofitVersion}"
+    compile "org.glassfish:javax.annotation:${javaAnnotationVersion}"
+    compile "com.squareup.okhttp3:okhttp:${okHttpVersion}"
 
-    compile 'com.jakewharton.timber:timber:4.3.1'
+    compile "com.jakewharton.timber:timber:${timberVersion}"
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
+    debugCompile "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}"
+    releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
+    testCompile "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
 
-    retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.3.0'
+    retrolambdaConfig "net.orfjackal.retrolambda:retrolambda:${retrolambdaConfigVersion}"
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    testCompile "junit:junit:${junitVersion}"
+    testCompile "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 buildscript {
@@ -93,9 +97,9 @@ buildscript {
 
     dependencies {
         // use some java 8 syntax in the project
-        classpath 'me.tatarka:gradle-retrolambda:3.3.1'
+        classpath "me.tatarka:gradle-retrolambda:${retrolambdaPluginVersion}"
         // check for updates of 3rd party libs:
         // `./gradlew dependencyUpdates -Drevision=release`
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
+        classpath "com.github.ben-manes:gradle-versions-plugin:${gradleVersionsVersion}"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ if (!secretPropertiesFile.exists()) {
 }
 
 subprojects {
+
+    //region secret variables
     /*
      * must define PAT_API_KEY in gradle.properties by adding pat_api=<KEY>
      */
@@ -49,6 +51,40 @@ subprojects {
      * This has to be generated from a signed keystore's SHA1 with similar instructions above
      */
     ext.googleMapsApiKeyRelease = "\"${secretProperties['google_maps_api_release']}\"" ?: '"Define Google Maps Release API Key in secrets.properties#google_maps_api_release"';
+    // endregion
 
+    // region versions for dependencies
+    // perhaps we should actually create these as gradle properties? I'm thinking this is ok.
+
+    // code language versions
+    ext.javaVersion = JavaVersion.VERSION_1_8
+
+    // google and android dependencies
+    ext.androidMinSdkVersion = 16
+    ext.androidTargetSdkVersion = 23
+    ext.androidBuildVersion = '23.0.3'
+    ext.googlePlayVersion = '10.0.1'
+    ext.androidDependencyVersion = '23.4.0'
+
+    // buildVersion for square dependencies and rxjava
+    ext.rxJavaVersion = '1.2.1'
+    ext.reactiveNetworkVersion = '0.6.0'
+    ext.retrofitVersion = '2.1.0'
+    ext.okHttpVersion = '3.4.1'
+    ext.timberVersion = '4.3.1'
+    ext.leakCanaryVersion = '1.5'
+
+    // build versions for retrolambda
+    ext.retrolambdaConfigVersion = '2.3.0'
+    ext.retrolambdaPluginVersion = '3.3.1'
+
+    // versions for other dependencies
+    ext.javaAnnotationVersion = '10.0-b28'
+    ext.gradleVersionsVersion = '0.12.0'
+
+    // versions for test dependencies
+    ext.junitVersion = '4.12'
+    ext.mockitoVersion = '1.9.5'
+    // endregion
 
 }


### PR DESCRIPTION
I think this will cleanup our code for the future, especially considering we will be creating multiple modules for the project. This way, version numbers for everything will be shared between each module without any issues. I did this by adding variables in `ext` which variables are named `ext.${dependencyName}Version` inside `<root>/build.gradle#subprojects`. Each subproject will simply just use `${dependencyName}Version` in their build.gradle's.