### PR TITLE
Update the detour URL

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,7 +366,7 @@
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="detour_info">Detour Information</string>
     <string name="clear_cache">Clear Route Cache</string>
-    <string name="detour_url">http://www.portauthority.org/paac/SchedulesMaps/Detours.aspx</string>
+    <string name="detour_url">http://www.portauthority.org/Detours/</string>
     <string name="servers_down_title">No buses?</string>
     <string name="servers_down_description">Wondering why there may be no buses on the map right now?\n\nThat is because Port Authority\'s servers may be down.\n\nWhile this issue is out of our control, we\'ll give you a status update ASAP.</string>
     <string name="servers_down_tell_me_more_button">What? Tell me more!</string>


### PR DESCRIPTION
The old detour URL of `http://www.portauthority.org/paac/SchedulesMaps/Detours.aspx` was deprecated. This change updates it to `http://www.portauthority.org/Detours/`, which is the new correct link.

@epicstar 