### PR TITLE
Update Target SDK Version to 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android.buildTypes.each { type ->
 }
 
 android {
-
+    buildToolsVersion versions.android.buildTools
     compileSdkVersion versions.android.targetSdk
     defaultConfig {
         applicationId "rectangledbmi.com.pittsburghrealtimetracker"
@@ -83,8 +83,6 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxjava:${versions.rx.java2}"
 
     debugImplementation "com.squareup.leakcanary:leakcanary-android:${versions.square.leakCanary}"
-    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${versions.square.leakCanary_no_op}"
-    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${versions.square.leakCanary_no_op}"
 
     testImplementation "junit:junit:${versions.test.junit}"
     testImplementation "org.mockito:mockito-core:${versions.test.mockito}"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:maxSdkVersion="22" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="22"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!--End permissions-->
@@ -30,7 +31,7 @@
 
         <activity
             android:name=".ui.MainActivity"
-            android:label="@string/app_name" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/PATTrackApplication.kt
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/PATTrackApplication.kt
@@ -1,12 +1,7 @@
 package rectangledbmi.com.pittsburghrealtimetracker
 
 import android.app.Application
-import android.content.Context
 import android.util.Log
-
-import com.squareup.leakcanary.LeakCanary
-import com.squareup.leakcanary.RefWatcher
-
 import timber.log.Timber
 
 /**
@@ -16,17 +11,8 @@ import timber.log.Timber
  */
 class PATTrackApplication : Application() {
 
-    private var refWatcher: RefWatcher? = null
-
     override fun onCreate() {
         super.onCreate()
-        if (LeakCanary.isInAnalyzerProcess(this)) {
-            // This process is dedicated to LeakCanary for heap analysis.
-            // You should not init your app in this process.
-            return
-        }
-        LeakCanary.install(this)
-        refWatcher = LeakCanary.install(this)
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         } else {
@@ -56,20 +42,6 @@ class PATTrackApplication : Application() {
                     }
                 }
             }
-        }
-    }
-
-    companion object {
-
-        /**
-         * Use this for [android.support.v4.app.Fragment]s to add a [RefWatcher] to look for
-         * leaks in [LeakCanary].
-         * @param context the application context
-         * @return a refWatcher
-         */
-        fun getRefWatcher(context: Context): RefWatcher? {
-            val application = context.applicationContext as PATTrackApplication
-            return application.refWatcher
         }
     }
 }

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/ui/map/BusMapFragment.kt
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/ui/map/BusMapFragment.kt
@@ -9,16 +9,15 @@ import android.graphics.*
 import android.location.Location
 import android.os.Build
 import android.os.Bundle
-import androidx.annotation.RequiresApi
-import com.google.android.material.snackbar.Snackbar
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.api.GoogleApiClient
 import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks
@@ -31,6 +30,7 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.*
+import com.google.android.material.snackbar.Snackbar
 import com.rectanglel.patstatic.errors.ErrorMessage
 import com.rectanglel.patstatic.model.PatApiService
 import com.rectanglel.patstatic.patterns.polylines.PolylineView
@@ -52,7 +52,6 @@ import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subscribers.DisposableSubscriber
 import rectangledbmi.com.pittsburghrealtimetracker.BuildConfig
-import rectangledbmi.com.pittsburghrealtimetracker.PATTrackApplication.Companion.getRefWatcher
 import rectangledbmi.com.pittsburghrealtimetracker.R
 import rectangledbmi.com.pittsburghrealtimetracker.patterns.PatternSelection
 import rectangledbmi.com.pittsburghrealtimetracker.patterns.PatternViewModel
@@ -281,11 +280,6 @@ class BusMapFragment : SelectionFragment(), ConnectionCallbacks, OnConnectionFai
 
     override fun onDestroy() {
         Timber.d("Destroying Bus Fragment")
-        activity?.let { activity ->
-            Timber.d("Adding leakcanary to fragment")
-            val refWatcher = getRefWatcher((activity))
-            refWatcher?.watch(this)
-        }
         if (unselectVehicleSubscription != null) {
             unselectVehicleSubscription?.dispose()
             unselectVehicleSubscription = null

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/ui/selection/NavigationDrawerFragment.kt
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/ui/selection/NavigationDrawerFragment.kt
@@ -19,7 +19,6 @@ import android.widget.Toast
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.subjects.PublishSubject
-import rectangledbmi.com.pittsburghrealtimetracker.PATTrackApplication.Companion.getRefWatcher
 import rectangledbmi.com.pittsburghrealtimetracker.R
 import rectangledbmi.com.pittsburghrealtimetracker.selection.Route
 import rectangledbmi.com.pittsburghrealtimetracker.selection.RouteSelection
@@ -113,10 +112,6 @@ class NavigationDrawerFragment : Fragment() {
     }
 
     override fun onDestroy() {
-        activity?.let { activity ->
-            val refWatcher = getRefWatcher(activity)
-            refWatcher?.watch(this)
-        }
         super.onDestroy()
     }
 

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/ReactiveHelper.kt
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/utils/ReactiveHelper.kt
@@ -40,14 +40,15 @@ fun retryIfInternet(disconnectionMessage: Consumer<Throwable>?, reconnectionMess
                         if (throwable.isInternetDown()) {
                             return@flatMap ReactiveNetwork
                                     .observeInternetConnectivity(InternetObservingSettings
-                                            .strategy(WalledGardenInternetObservingStrategy())
-                                            .initialInterval(2000)
-                                            .interval(2000)
-                                            .port(80)
-                                            .timeout(2000)
-                                            .errorHandler(DefaultErrorHandler())
-                                            .host("http://clients3.google.com/generate_204")
-                                            .build())
+                                        .builder()
+                                        .strategy(WalledGardenInternetObservingStrategy())
+                                        .initialInterval(2000)
+                                        .interval(2000)
+                                        .port(80)
+                                        .timeout(2000)
+                                        .errorHandler(DefaultErrorHandler())
+                                        .host("http://clients3.google.com/generate_204")
+                                        .build())
                                     .skipWhile(Boolean::not)
                                     .doOnNext { isConnected: Boolean ->
                                         if (isConnected) {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
             rx: [
                     android: '2.1.1',
                     java2: '2.2.21',
-                    network: '1.0.0'
+                    network: '3.0.8'
             ],
             square: [
                     leakCanary: '2.10',

--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,10 @@ ext {
                     target: JavaVersion.VERSION_1_8,
             ],
             android: [
-                    buildTools: '30.0.2',
+                    buildTools: '33.0.2',
                     minSdk: 21,
                     support: '28.0.0',
-                    targetSdk: 30
+                    targetSdk: 33
             ],
             google: [
                     play: '18.0.0',
@@ -84,8 +84,7 @@ ext {
                     network: '1.0.0'
             ],
             square: [
-                    leakCanary: '1.5',
-                    leakCanary_no_op: '1.6.3',
+                    leakCanary: '2.10',
                     okHttp: '3.14.9',
                     retrofit: '2.7.2',
                     rxjava2Adapter: '2.7.2',


### PR DESCRIPTION
added coarse location permission bc it's required, too.

I had to update LeakCanary and ReactiveNetwork due to them depending on the legacy version of android libs, causing version dependency issues. Upon update, they now depend on the "Jetified" versions of the Android libraries. 