### PR TITLE
Convert Dependencies to Gradle Version Catalogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,6 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'com.github.ben-manes.versions'
-
-// version dependnecies should be added via ../build.gradle -> `region versions for dependencies`
-// I did this since we can have multiple projects and they should all share the same versions
-// only exception to this are the published versions of each code specific to the project
-
-android.buildTypes.each { type ->
-    type.buildConfigField 'String', 'PAT_API_KEY', keys.truetime.release // variable defined in `../build.gradle`
+plugins {
+    alias libs.plugins.android.application
+    alias libs.plugins.kotlin.android
 }
 
 android {
@@ -23,10 +16,12 @@ android {
     buildTypes {
 
         debug {
+            buildConfigField 'String', 'PAT_API_KEY', keys.truetime.debug // variable defined in `../build.gradle`
             minifyEnabled false
             resValue "string", "google_maps_key", keys.google.maps.debug // variable defined in `../build.gradle`
         }
         release {
+            buildConfigField 'String', 'PAT_API_KEY', keys.truetime.release // variable defined in `../build.gradle`
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             resValue "string", "google_maps_key", keys.google.maps.release // variable defined in `../build.gradle`
@@ -40,7 +35,7 @@ android {
         main.java.srcDirs += "src/main/kotlin"
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = versions.java.version
     }
     lint {
         warning 'InvalidPackage'
@@ -62,53 +57,23 @@ dependencies {
     implementation project(path: ':pat-static')
 //    releaseImplementation project(path: ':pat-static', configuration: "release")
 
-    repositories {
-        mavenCentral()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    }
+    implementation libs.bundles.android
+    implementation libs.bundles.android.app
+    implementation libs.bundles.google.play
 
-    //google play services maps
-    implementation "com.google.android.gms:play-services-maps:${versions.google.play}"
-    //google play services location and places
-    implementation "com.google.android.gms:play-services-location:${versions.google.play}"
-    implementation "com.google.android.gms:play-services-places:${versions.google.places}"
+    implementation libs.bundles.restcalls
 
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    implementation libs.rx.android
+    implementation libs.rx.java
+    implementation libs.rx.network
 
-    implementation 'androidx.mediarouter:mediarouter:1.3.1'
-
-    implementation "androidx.fragment:fragment-ktx:1.3.6"
+    testImplementation libs.bundles.testing
 
     //3rd party android libraries
-    implementation "com.github.pwittchen:reactivenetwork-rx2:${versions.rx.network}"
-    implementation "com.jakewharton.timber:timber:${versions.square.timber}"
-    implementation "com.squareup.retrofit2:retrofit:${versions.square.retrofit}"
-    implementation "com.squareup.retrofit2:converter-gson:${versions.square.retrofit}"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:${versions.square.rxjava2Adapter}"
-    implementation "io.reactivex.rxjava2:rxandroid:${versions.rx.android}"
-    implementation "io.reactivex.rxjava2:rxjava:${versions.rx.java2}"
 
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:${versions.square.leakCanary}"
+    implementation libs.kotlin.stdlib
+    implementation libs.javax.annotations
 
-    testImplementation "junit:junit:${versions.test.junit}"
-    testImplementation "org.mockito:mockito-core:${versions.test.mockito}"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.glassfish:javax.annotation:10.0-b28'
+    debugImplementation libs.square.leakcanary
 
-}
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        // check for updates of 3rd party libs:
-        // `./gradlew dependencyUpdates -Drevision=release`
-        classpath "com.github.ben-manes:gradle-versions-plugin:${versions.gradleVersions}"
-    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,6 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(path: ':pat-static')
-//    releaseImplementation project(path: ':pat-static', configuration: "release")
 
     implementation libs.bundles.android
     implementation libs.bundles.android.app

--- a/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/ui/map/BusMapFragment.kt
+++ b/app/src/main/java/rectangledbmi/com/pittsburghrealtimetracker/ui/map/BusMapFragment.kt
@@ -599,22 +599,24 @@ class BusMapFragment : SelectionFragment(), ConnectionCallbacks, OnConnectionFai
             requestPermissions(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION), CENTER_MAP_LOCATION_CODE)
             return
         }
-        val lastLocation = LocationServices.FusedLocationApi.getLastLocation(googleApiClient)
-        // use the last location if found and if less than 1 hour
-        if ((lastLocation != null) && isInPittsburgh(lastLocation) && (System.currentTimeMillis() - lastLocation.time < 3600000)) {
-            Timber.i("Using last location to center map.")
-            val latLng = LatLng(lastLocation.latitude, lastLocation.longitude)
-            mMap?.animateCamera(CameraUpdateFactory.newLatLngZoom(latLng, zoomStopVisibility))
-        } else { // request one location update
-            Timber.i("Creating 1 location request to center map on you.")
-            val gLocationRequest = LocationRequest.create()
+        googleApiClient?.let { googleApiClient ->
+            val lastLocation = LocationServices.FusedLocationApi.getLastLocation(googleApiClient)
+            // use the last location if found and if less than 1 hour
+            if ((lastLocation != null) && isInPittsburgh(lastLocation) && (System.currentTimeMillis() - lastLocation.time < 3600000)) {
+                Timber.i("Using last location to center map.")
+                val latLng = LatLng(lastLocation.latitude, lastLocation.longitude)
+                mMap?.animateCamera(CameraUpdateFactory.newLatLngZoom(latLng, zoomStopVisibility))
+            } else { // request one location update
+                Timber.i("Creating 1 location request to center map on you.")
+                val gLocationRequest = LocationRequest.create()
                     .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY)
                     .setInterval(1000)
                     .setExpirationTime(10000) // set expiration 10 seconds
                     .setNumUpdates(1) // only do one update. needs above call for expiration
-            LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, gLocationRequest, this)
+                LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, gLocationRequest, this)
+            }
+            enableGoogleMapLocation()
         }
-        enableGoogleMapLocation()
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript {
-    ext.kotlin_version = '1.8.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-apply plugin: 'kotlin'
-
-allprojects {
-    repositories {
-        mavenCentral()
-        google()
-    }
+plugins {
+    alias libs.plugins.android.application apply false
+    alias libs.plugins.kotlin.android apply false
+    alias libs.plugins.kotlin apply false
+    alias libs.plugins.benManes.versions apply true
 }
 
 // load secrets.properties for properties that should be part of app but not in source control
@@ -54,51 +38,23 @@ ext {
              * must define PAT_API_KEY in gradle.properties by adding pat_api=<KEY>
              */
             truetime: [
-                    debug: "\"${System.getenv("PAT_API_DEBUG") ?: secretProperties['pat_api_debug']}" ?: '"Define Port Authority TrueTime API Key in secrets.properties#pat_api_debug"',
+                    debug: "\"${System.getenv("PAT_API_DEBUG") ?: secretProperties['pat_api_debug']}\"" ?: '"Define Port Authority TrueTime API Key in secrets.properties#pat_api_debug"',
                     release: "\"${System.getenv("PAT_API_RELEASE") ?: secretProperties['pat_api']}\"" ?: '"Define Port Authority TrueTime API Key in secrets.properties#pat_api"'
             ]
     ]
 
-    // versions for all dependencies
+    // versions not defined in gradle/libs.versions.toml
     versions = [
             java: [
-                    annotation: '10.0-b28',
+                    languageVersion: JavaLanguageVersion.of(8),
                     target: JavaVersion.VERSION_1_8,
+                    version: "1.8",
             ],
             android: [
                     buildTools: '33.0.2',
                     minSdk: 21,
-                    support: '28.0.0',
                     targetSdk: 33
             ],
-            google: [
-                    play: '18.0.0',
-                    places: '17.0.0'
-            ],
 
-            gradleVersions: '0.11.1',
-
-            rx: [
-                    android: '2.1.1',
-                    java2: '2.2.21',
-                    network: '3.0.8'
-            ],
-            square: [
-                    leakCanary: '2.10',
-                    okHttp: '3.14.9',
-                    retrofit: '2.7.2',
-                    rxjava2Adapter: '2.7.2',
-                    timber: '5.0.1',
-            ],
-
-            test: [
-                    junit: '4.12',
-                    mockito: '4.5.1',
-                    mockitoKotlin: '4.5.1'
-            ],
-
-            apache: [
-                    commons: '2.5'
-            ]
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
 android.useAndroidX=true
-android.enableJetifier=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ rx-java = "2.2.21"
 rx-network = "3.0.8"
 
 square-leakcanary = "2.10"
-square-retrofit = "2.9.0"
+square-retrofit = "2.7.2"
 square-okhttp = "4.10.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,113 @@
+[versions]
+# NOTE: Some are defined in the top level build.gradle#ext.versions property
+# because they are not versions defined in our toml.
+android-buildtools = "33.0.2"
+android-plugin = "7.4.2"
+
+# NOTE: kotlin version must match Android Studio Kotlin Plugin Version:
+# Tools -> Kotlin -> Configure Kotlin Updates
+kotlin = "1.8.0"
+
+androidx-appcompat = "1.6.1"
+androidx-core = "1.9.0"
+androidx-fragment = "1.5.6"
+androidx-legacy = "1.0.0"
+androidx-lifecycle = "2.6.1"
+androidx-mediarouter = "1.3.1"
+androidx-recyclerview = "1.3.0"
+
+benManes-versions = "0.46.0"
+
+google-material = "1.8.0"
+google-play-location = "18.0.0"
+google-play-maps = "18.1.0"
+google-play-places = "3.0.0"
+
+jakewharton-timber = "5.0.1"
+
+javax-annotations = "10.0-b28"
+
+junit = "4.13.2"
+mockito = "4.5.1"
+
+rx-android = "2.1.1"
+rx-java = "2.2.21"
+rx-network = "3.0.8"
+
+square-leakcanary = "2.10"
+square-retrofit = "2.9.0"
+square-okhttp = "4.10.0"
+
+[libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment"}
+androidx-lifecycle = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+androidx-legacy = { module = "androidx.legacy:legacy-support-v4", version.ref = "androidx-legacy" }
+androidx-mediarouter = { module = "androidx.mediarouter:mediarouter", version.ref = "androidx-mediarouter" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview"}
+
+google-material = { module = "com.google.android.material:material", version.ref = "google-material" }
+google-play-location = { module = "com.google.android.gms:play-services-location", version.ref = "google-play-location" }
+google-play-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "google-play-maps" }
+# TODO: test if needed
+google-play-places = { module = "com.google.android.libraries.places:places", version.ref = "google-play-places" }
+
+jakewharton-timber = { module = "com.jakewharton.timber:timber", version.ref = "jakewharton-timber" }
+
+javax-annotations = { module = "org.glassfish:javax.annotation", version.ref = "javax-annotations" }
+
+kotlin-gradleplugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+
+junit = { module = "junit:junit", version.ref = "junit" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+
+rx-android = { module = "io.reactivex.rxjava2:rxandroid", version.ref = "rx-android" }
+rx-java = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rx-java" }
+rx-network = { module = "com.github.pwittchen:reactivenetwork-rx2", version.ref = "rx-network" }
+
+square-leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "square-leakcanary" }
+square-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "square-okhttp" }
+square-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "square-retrofit" }
+square-retrofit-adapter = { module = "com.squareup.retrofit2:adapter-rxjava2", version.ref = "square-retrofit" }
+square-retrofit-converter = { module = "com.squareup.retrofit2:converter-gson", version.ref = "square-retrofit" }
+
+[bundles]
+android = [
+    "androidx-appcompat",
+    "androidx-core",
+    "androidx-fragment",
+    "androidx-lifecycle",
+    "androidx-mediarouter",
+    "androidx-recyclerview",
+    "jakewharton-timber",
+]
+
+android-app = [
+    "google-material"
+]
+
+google-play = [
+    "google-play-location",
+    "google-play-maps",
+    "google-play-places"
+]
+
+restcalls = [
+    "square-okhttp",
+    "square-retrofit",
+    "square-retrofit-converter",
+    "square-retrofit-adapter"
+]
+
+testing = [
+    "junit",
+    "mockito-core"
+]
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-plugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+benManes-versions = { id = "com.github.ben-manes.versions", version.ref = "benManes-versions" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 # NOTE: Some are defined in the top level build.gradle#ext.versions property
-# because they are not versions defined in our toml.
-android-buildtools = "33.0.2"
-android-plugin = "7.4.2"
+# because they are not versions used in this file such as build tools version and target SDK
 
-# NOTE: kotlin version must match Android Studio Kotlin Plugin Version:
+# Note: This MUST match the Android Studio Kotlin plugin version!!!
+# ignore dependabot only for kotlin version!!!
 # Tools -> Kotlin -> Configure Kotlin Updates
 kotlin = "1.8.0"
+
+android-plugin = "7.4.2"
 
 androidx-appcompat = "1.6.1"
 androidx-core = "1.9.0"

--- a/pat-static/build.gradle
+++ b/pat-static/build.gradle
@@ -1,47 +1,22 @@
-apply plugin: 'kotlin'
-
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        // check for updates of 3rd party libs:
-        // `./gradlew dependencyUpdates -Drevision=release`
-        classpath "com.github.ben-manes:gradle-versions-plugin:${versions.gradleVersions}"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    alias libs.plugins.kotlin
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = versions.java.languageVersion
     }
 }
 
 compileJava {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    sourceCompatibility = versions.java.version
+    targetCompatibility = versions.java.version
 }
 
 dependencies {
-    repositories {
-        mavenCentral()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    }
-
-    implementation "io.reactivex.rxjava2:rxjava:${versions.rx.java2}"
-
-    implementation "com.squareup.retrofit2:retrofit:${versions.square.retrofit}"
-    implementation "com.squareup.retrofit2:converter-gson:${versions.square.retrofit}"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:${versions.square.rxjava2Adapter}"
-    implementation "com.squareup.okhttp3:okhttp:${versions.square.okHttp}"
-
-    testImplementation "junit:junit:${versions.test.junit}"
-    testImplementation "org.mockito:mockito-core:${versions.test.mockito}"
-
-    implementation  "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation libs.bundles.restcalls
+    testImplementation libs.bundles.testing
+    implementation  libs.kotlin.stdlib
 }
 
 sourceSets {
@@ -63,6 +38,3 @@ task cleanCachedRoutes(type: Delete) {
 }
 
 jar.dependsOn cacheRoutes
-repositories {
-    mavenCentral()
-}

--- a/pat-static/src/main/java/com/rectanglel/patstatic/model/PatApiServiceImpl.kt
+++ b/pat-static/src/main/java/com/rectanglel/patstatic/model/PatApiServiceImpl.kt
@@ -97,7 +97,7 @@ class PatApiServiceImpl(apiKey: String,
             return { predictionResponse ->
                 predictionResponse
                         .map { it.bustimeResponse }
-                        .map { it.prd }
+                        .map { it!!.prd } // TODO: FIX
                         .compose(applySchedulersSingle<List<Prd>>())
             }
         }
@@ -114,7 +114,7 @@ class PatApiServiceImpl(apiKey: String,
                     .readTimeout(5, TimeUnit.SECONDS)
                     .addInterceptor { chain ->
                         val original = chain.request()
-                        val originalHttpUrl = original.url()
+                        val originalHttpUrl = original.url
 
                         val url = originalHttpUrl.newBuilder()
                                 .addQueryParameter("key", apiKey)

--- a/pat-static/src/main/java/io/paour/github/natorder/NaturalOrderComparator.kt
+++ b/pat-static/src/main/java/io/paour/github/natorder/NaturalOrderComparator.kt
@@ -46,7 +46,7 @@ class NaturalOrderComparator<T> : Comparator<T> // epicstar: change to abide by 
                 !cb.isDigit()                      -> return +1
                 ca < cb && bias == 0               -> -1
                 ca > cb && bias == 0               -> +1
-                ca.toInt() == 0 && cb.toInt() == 0 -> return bias
+                ca.code == 0 && cb.code == 0 -> return bias
                 else                               -> bias
             }
 

--- a/pat-static/src/main/kotlin/com/rectanglel/patstatic/patterns/PatternDataManager.kt
+++ b/pat-static/src/main/kotlin/com/rectanglel/patstatic/patterns/PatternDataManager.kt
@@ -83,7 +83,7 @@ class PatternDataManager(dataDirectory: File,
                 .map(PatternResponse::patternResponse)
                 .map { bustimePatternResponse ->
                     try {
-                        val patterns = bustimePatternResponse.ptr
+                        val patterns = bustimePatternResponse!!.ptr // TODO: FIX
                         val patternsFile = getPatternsFile(rt)
                         saveAsJson(patterns, patternsFile)
                         patterns

--- a/pat-static/src/test/java/com/rectanglel/patstatic/buildutils/TrueTimeDataCacher.kt
+++ b/pat-static/src/test/java/com/rectanglel/patstatic/buildutils/TrueTimeDataCacher.kt
@@ -32,11 +32,13 @@ class TrueTimeDataCacher(apiKey: String, private val cacheDirectory: File) {
                                 val routeNumber = route.routeNumber
                                 File(cacheDirectory, String.format("lineinfo/%s.json", routeNumber)).exists()
                             }
-                            .zipWith(Observable.interval(0, 500, TimeUnit.MILLISECONDS), BiFunction { stuff: BusRoute?, _: Long? -> stuff!! })
+                            .zipWith(Observable.interval(0, 500, TimeUnit.MILLISECONDS)
+                            ) { stuff: BusRoute?, _: Long? -> stuff!! }
                 }
                 .buffer(8)
-                .zipWith(Observable.interval(0, 5, TimeUnit.SECONDS), BiFunction { stuff: List<BusRoute?>?, _: Long? -> stuff!! })
-                .flatMapIterable { routes1: List<BusRoute?>? -> routes1 }
+                .zipWith(Observable.interval(0, 5, TimeUnit.SECONDS)
+                ) { stuff, _: Long? -> stuff!! }
+            .flatMapIterable { routes1 -> routes1 }
                 .map(BusRoute::routeNumber)
                 .flatMap { routeNumber: String? ->
                     patApiService

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,40 @@
+pluginManagement {
+
+    /**
+     * The pluginManagement {repositories {...}} block configures the
+     * repositories Gradle uses to search or download the Gradle plugins and
+     * their transitive dependencies. Gradle pre-configures support for remote
+     * repositories such as JCenter, Maven Central, and Ivy. You can also use
+     * local repositories or define your own remote repositories. The code below
+     * defines the Gradle Plugin Portal, Google's Maven repository,
+     * and the Maven Central Repository as the repositories Gradle should use to look for its
+     * dependencies.
+     */
+
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+
+    /**
+     * The dependencyResolutionManagement {repositories {...}}
+     * block is where you configure the repositories and dependencies used by
+     * all modules in your project, such as libraries that you are using to
+     * create your application. However, you should configure module-specific
+     * dependencies in each module-level build.gradle file. For new projects,
+     * Android Studio includes Google's Maven repository and the Maven Central
+     * Repository by default, but it does not configure any dependencies (unless
+     * you select a template that requires some).
+     */
+
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app', ':pat-static'


### PR DESCRIPTION
Closes #360 

This is the gradle and dependabot official way to solve #311.

Gives us the ability for depend

Lose ability for IDE to check matching Kotlin version. However... I'd rather trade dependabot updates for matching Kotlin version. Easy to check anyway.